### PR TITLE
Post-hackathon: add Ownable to contracts

### DIFF
--- a/packages/hardhat/contracts/DonationEASResolver.sol
+++ b/packages/hardhat/contracts/DonationEASResolver.sol
@@ -2,21 +2,22 @@
 
 pragma solidity 0.8.19;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@ethereum-attestation-service/eas-contracts/contracts/resolver/SchemaResolver.sol";
 import {IEAS, Attestation} from "@ethereum-attestation-service/eas-contracts/contracts/IEAS.sol";
 import "./HabitatNFT.sol";
 
-contract DonationEASResolver is SchemaResolver {
+contract DonationEASResolver is Ownable, SchemaResolver {
     // UID of EAS schema: 0x3bb54e554f4bba20b4c98584863a60985e4e021536311c3cf1798b6158015979
     HabitatNFT public habitatNFT;
 
     event NewDonation(address to, address from, uint256 value, bytes32 tx_hash);
 
-    constructor(IEAS eas, address _habitat) SchemaResolver(eas) {
+    constructor(IEAS eas, address _habitat) SchemaResolver(eas) Ownable() {
         habitatNFT = HabitatNFT(_habitat);
     }
 
-    function setHabitatNFT(address _habitat) public {
+    function setHabitatNFT(address _habitat) public onlyOwner {
         habitatNFT = HabitatNFT(_habitat);
     }
 

--- a/packages/hardhat/contracts/NFTree.sol
+++ b/packages/hardhat/contracts/NFTree.sol
@@ -4,10 +4,11 @@ pragma solidity ^0.8.0;
 import "./interfaces/IERC4883.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "./HabitatNFT.sol";
 
 
-contract NFTree is ERC721Enumerable, ERC721URIStorage, IERC4883 {
+contract NFTree is Ownable, ERC721Enumerable, ERC721URIStorage, IERC4883 {
     uint256 public constant POINTS_TO_MINT = 10;
     HabitatNFT public habitat;
 
@@ -16,11 +17,11 @@ contract NFTree is ERC721Enumerable, ERC721URIStorage, IERC4883 {
         _;
     }
 
-    constructor() ERC721("NFTree", "Tree") {
+    constructor() ERC721("NFTree", "Tree") Ownable() {
         
     }
 
-    function setHabitatNFT(address _habitat) public {
+    function setHabitatNFT(address _habitat) public onlyOwner {
         habitat = HabitatNFT(_habitat);
     }
 


### PR DESCRIPTION
This hackathon project will clearly still need more refinement to improve the security and usability, but at the very least certain functions should be protected by `onlyOwner`